### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.3.2
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## [v7.3.1](https://github.com/oakromulo/flutter_analytics/tree/v7.3.1) - 2020-03-11
 
 - Header `batch` added in order to roughly identify the encoded `batch` on the body, simplifying

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_analytics
 description: A barebones Analytics SDK to collect anonymous metadata from flutter apps.
-version: 7.3.1
+version: 7.3.2
 homepage: https://github.com/oakromulo/flutter_analytics
 repository: https://github.com/oakromulo/flutter_analytics.git
 issue_tracker: https://github.com/oakromulo/flutter_analytics/issues
@@ -19,7 +19,7 @@ dependencies:
   flutter_udid: ^1.0.1
   http: ^0.12.0+4
   location: ^2.5.3
-  package_info: ^0.4.0+14
+  package_info: '>=0.4.0+14 <2.0.0'
   path_provider: ^1.6.5
   recase: ^3.0.0
   sim_info: ^0.1.1


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).